### PR TITLE
Use right cased class when initializing proxy

### DIFF
--- a/lib/planetscale.rb
+++ b/lib/planetscale.rb
@@ -7,7 +7,7 @@ require 'pry'
 module PlanetScale
   class <<self
     def start(auth_method: Proxy::AUTH_AUTO, **kwargs)
-      @proxy = Planetscale::Proxy.new(auth_method: auth_method, **kwargs)
+      @proxy = PlanetScale::Proxy.new(auth_method: auth_method, **kwargs)
       @proxy.start
     end
   end


### PR DESCRIPTION
Otherwise you get 

```
/Users/nickvanw/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/planetscale-0.6.0.3c0eb6ba/lib/planetscale.rb:10:in `start': uninitialized constant Planetscale (NameError)
```