### PR TITLE
Use ruby/setup-ruby, and bundler cache for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: Ruby Gem - Run Tests
 
 on:
   push:
@@ -13,12 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
-    - name: Bundle and Test
+        ruby-version: 2.7.3
+        bundler-cache: true
+    - name: Build and Test
       run: |
-        gem install bundler
-        bundle install
         go build -v -buildmode=c-shared -o proxy/planetscale-linux.so
         bundle exec rake test

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: Ruby Gem - Build + Publish
 
 on:
   push:
@@ -15,9 +15,10 @@ jobs:
     - uses: nickvanw/actions-setup-docker@master
 
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
+        ruby-version: 2.7.3
+        bundler-cache: true
 
     - name: Add SHORT_SHA env property with commit short sha
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV   


### PR DESCRIPTION
@mscoutermarsh 👋🏻 ended up checking out @planetscale - super cool btw - and going down this random hole. 

TLDR: https://github.com/actions/setup-ruby is dead, long live https://github.com/ruby/setup-ruby and it's [caching awesomeness](https://github.com/ruby/setup-ruby#bundler). Also, the naming of the workflows wasn't super clear, so I "fixed" that too.

Hopefully y'all will have faster builds.