### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/lib/planetscale/version.rb
+++ b/lib/planetscale/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PlanetScale
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
This is so that we can release a new version everywhere with the proper FFI libraries included. 