### PR TITLE
Support single quote requires when running the install scaffold

### DIFF
--- a/lib/generators/planetscale/install_generator.rb
+++ b/lib/generators/planetscale/install_generator.rb
@@ -23,9 +23,11 @@ class Planetscale
       @org ||= options[:organization]
     end 
 
+    APPLICATION_REQUIRE_REGEX = /(require_relative ("|')application("|')\n)/.freeze
+
     def create_planetscale_config
       create_file "config/planetscale.rb", "PlanetScale.start(org: '#{@org}')\n"
-      inject_into_file "config/environment.rb", after: "require_relative \"application\"\n" do <<~'RUBY'
+      inject_into_file "config/environment.rb", after: APPLICATION_REQUIRE_REGEX do <<~'RUBY'
         require_relative "planetscale"
       RUBY
       end


### PR DESCRIPTION
Was running into the following issue:

```
$ bundle exec rails generate planetscale:install --organization $ORG_NAME
Running via Spring preloader in process 49258
      create  config/planetscale.rb
File unchanged! The supplied flag value not found!  config/environment.rb
```

This was because my `config/environment.rb` was using single quotes rather than the expected double quotes:

```rb
# frozen_string_literal: true

# Load the Rails application.
require_relative 'application'

# Initialize the Rails application.
Rails.application.initialize!
```

I've tested the patch out locally and it's now working:

```
$ bundle exec rails generate planetscale:install --organization $ORG_NAME
Running via Spring preloader in process 51338
   identical  config/planetscale.rb
      insert  config/environment.rb
Installed!

Configure your database.yaml like so:

development:
  <<: *default
  username: root
  host: 127.0.0.1
  port: 3305
  database: <db_name>

Or set DATABASE_URL=mysql2://root:@127.0.0.1:3305/<db_name>
```