### PR TITLE
Rename environment vars from PSCALE to PLANETSCALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ development:
   database: <db_name>
 ```
 
-Now, your Rails app will boot the proxy as the app is starting, and connect to the `main` branch on your DB. 
+Now, your Rails app will boot the proxy as the app is starting, and connect to the `main` branch on your DB.
 
 ### Service Token Authentication
 
@@ -66,11 +66,11 @@ To use this Gem in 'production', we'll start by creating a PlanetScale Service T
 To configure your application in production, you'll need to feed it all of the right information via environment variables:
 
 ```
-PSCALE_ORG=<org_name>
-PSCALE_DB=<db_name>
-PSCALE_DB_BRANCH=main
-PSCALE_TOKEN_NAME=0sph6kvz5bxi
-PSCALE_TOKEN=<redacted>
+PLANETSCALE_ORG=<org_name>
+PLANETSCALE_DB=<db_name>
+PLANETSCALE_DB_BRANCH=main
+PLANETSCALE_TOKEN_NAME=0sph6kvz5bxi
+PLANETSCALE_TOKEN=<redacted>
 ```
 
 ## Development
@@ -85,4 +85,4 @@ Bug reports and pull requests are welcome. This Gem is internal to PlanetScale c
 
 ## License
 
-Currently this Gem is specified under the MIT license, however it has not been made public. Care will be taken before this is done to choose an appropriate license. 
+Currently this Gem is specified under the MIT license, however it has not been made public. Care will be taken before this is done to choose an appropriate license.

--- a/lib/generators/planetscale/install_generator.rb
+++ b/lib/generators/planetscale/install_generator.rb
@@ -1,12 +1,12 @@
 require 'rails/generators'
 
 class Planetscale
-  class InstallGenerator < Rails::Generators::Base    
+  class InstallGenerator < Rails::Generators::Base
     class_option :organization, type: :string, default: ''
 
     def read_config
       @database = "<db_name>"
-      file_path = File.join(Rails.root, PlanetScale::Proxy::PSCALE_FILE)
+      file_path = File.join(Rails.root, PlanetScale::Proxy::PLANETSCALE_FILE)
       return unless File.exist?(file_path)
 
       data = YAML.safe_load(File.read(file_path))
@@ -21,7 +21,7 @@ class Planetscale
       end
 
       @org ||= options[:organization]
-    end 
+    end
 
     APPLICATION_REQUIRE_REGEX = /(require_relative ("|')application("|')\n)/.freeze
 
@@ -34,7 +34,7 @@ class Planetscale
     end
 
     # todo(nickvanw): When we get rid of DB passwords, this can mostly go away, and we can just
-    # return the `DATABSE_URL` that the user should use. 
+    # return the `DATABSE_URL` that the user should use.
     def print_database_yaml
       d =
       <<~EOS
@@ -52,7 +52,7 @@ class Planetscale
       puts d
       puts "\nOr set DATABASE_URL=#{db_url}"
     end
-  end 
+  end
 end
 
 class String

--- a/lib/planetscale.rb
+++ b/lib/planetscale.rb
@@ -13,10 +13,10 @@ module PlanetScale
 
   class Proxy
     AUTH_SERVICE_TOKEN = 1 # Use Service Tokens for Auth
-    AUTH_PSCALE = 2 # Use externally configured `pscale` auth & org config
+    AUTH_PLANETSCALE = 2 # Use externally configured `pscale` auth & org config
     AUTH_STATIC = 3 # Use a locally provided certificate
     AUTH_AUTO = 4 # Default. Let the Gem figure it out
-    PSCALE_FILE = '.pscale.yml'
+    PLANETSCALE_FILE = '.pscale.yml'
 
     class ProxyError < StandardError
     end
@@ -36,26 +36,26 @@ module PlanetScale
       @auth_method = auth_method
 
       default_file = if defined?(Rails.root)
-        File.join(Rails.root, PSCALE_FILE) if defined?(Rails.root)
+        File.join(Rails.root, PLANETSCALE_FILE) if defined?(Rails.root)
       else
-        PSCALE_FILE
+        PLANETSCALE_FILE
       end
 
-      @cfg_file = kwargs[:cfg_file] || ENV['PSCALE_DB_CONFIG'] || default_file
+      @cfg_file = kwargs[:cfg_file] || ENV['PLANETSCALE_DB_CONFIG'] || default_file
 
-      @branch_name = kwargs[:branch] || ENV['PSCALE_DB_BRANCH']
+      @branch_name = kwargs[:branch] || ENV['PLANETSCALE_DB_BRANCH']
       @branch = lookup_branch
 
-      @db_name = kwargs[:db] || ENV['PSCALE_DB']
+      @db_name = kwargs[:db] || ENV['PLANETSCALE_DB']
       @db = lookup_database
 
-      @org_name = kwargs[:org] || ENV['PSCALE_ORG']
+      @org_name = kwargs[:org] || ENV['PLANETSCALE_ORG']
       @org = lookup_org
 
       raise ArgumentError, 'missing required configuration variables' if [@db, @branch, @org].any?(&:nil?)
 
-      @token_name = kwargs[:token_id] || ENV['PSCALE_TOKEN_NAME']
-      @token = kwargs[:token] || ENV['PSCALE_TOKEN']
+      @token_name = kwargs[:token_id] || ENV['PLANETSCALE_TOKEN_NAME']
+      @token = kwargs[:token] || ENV['PLANETSCALE_TOKEN']
 
       if @token && @token_name && auto_auth?
         @auth_method = AUTH_SERVICE_TOKEN
@@ -78,7 +78,7 @@ module PlanetScale
 
     def start
       ret = case @auth_method
-      when AUTH_PSCALE
+      when AUTH_PLANETSCALE
         startfromenv(@org, @db, @branch, @listen_addr)
       when AUTH_AUTO
         startfromenv(@org, @db, @branch, @listen_addr)
@@ -123,7 +123,7 @@ module PlanetScale
     end
 
     def env_auth?
-      @auth_method == AUTH_PSCALE
+      @auth_method == AUTH_PLANETSCALE
     end
 
     def token_auth?


### PR DESCRIPTION
Standardize  environment variables names in clients 

Reference: https://github.com/planetscale/project-big-bang/issues/405