### PR TITLE
M1 Support

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Build shared library on OS X
       run: go build -v -buildmode=c-shared -o proxy/planetscale-darwin.so
 
+    - name: Build shared library on Apple Silicon OS X
+      run: GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-arm64.so
+
     - name: Build shared library on Linux
       run: docker run -v $(pwd):/planetscale-ruby golang sh -c 'cd /planetscale-ruby && go build -v -buildmode=c-shared -o proxy/planetscale-linux.so'
 

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,14 @@ bundle install
 OS="`uname`"
 case $OS in
   'Darwin')
-    go build -v -buildmode=c-shared -o proxy/planetscale-darwin.so
+    case $(uname -m) in
+      'arm64')
+        GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-arm64.so
+      ;;
+      *)
+        go build -v -buildmode=c-shared -o proxy/planetscale-darwin.so
+      ;;
+    esac
     ;;
   'Linux')
     go build -v -buildmode=c-shared -o proxy/planetscale-linux.so

--- a/lib/planetscale.rb
+++ b/lib/planetscale.rb
@@ -27,7 +27,7 @@ module PlanetScale
       layout :r0, :pointer, :r1, :pointer
     end
 
-    ffi_lib File.expand_path("../../proxy/planetscale-#{Gem::Platform.local.os}.so", __FILE__)
+    ffi_lib File.expand_path("../../proxy/planetscale-#{Gem::Platform.local.os}#{'-arm64' if Gem::Platform.local.cpu == 'arm64'}.so", __FILE__)
     attach_function :startfromenv, %i[string string string string], ProxyReturn.by_value
     attach_function :startfromtoken, %i[string string string string string string], ProxyReturn.by_value
     attach_function :startfromstatic, %i[string string string string string string string string string], ProxyReturn.by_value


### PR DESCRIPTION
Hi! I tried to use Planetscale this weekend for a Rails project and noticed that the gem was not working on my M1 mac.
I made this small PR to at least be able to boot rails with the **planetscale** gem.

I tried the entire tutorial written here https://docs.planetscale.com/tutorial/connect-rails-app and did not get any particular issue. 

I wanted to directly add the line to compile the proxy lib for arm64 for Linux but as I'm not familiar with the entire codebase I wasn't sure if it would break something.