### PR TITLE
Setup build for creating a universal MacOS binary

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build + Publish
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 25
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         go-version: ^1.17
 
     - name: Build shared library on OS X
-      run: go build -v -buildmode=c-shared -o proxy/planetscale-darwin.so
+      run: bin/build-darwin
 
     - name: Install Docker
       uses: docker-practice/actions-setup-docker@master

--- a/bin/build-darwin
+++ b/bin/build-darwin
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GOOS=darwin GOARCH=amd64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-amd64.so
+GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-arm64.so
+
+lipo -create -output proxy/planetscale-darwin.so proxy/planetscale-darwin-amd64.so  proxy/planetscale-darwin-arm64.so
+
+rm -rf proxy/planetscale-darwin-amd64.so proxy/planetscale-darwin-arm64.so

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ bundle install
 OS="`uname`"
 case $OS in
   'Darwin')
-    go build -v -buildmode=c-shared -o proxy/planetscale-darwin.so
+    bin/build-darwin
     ;;
   'Linux')
     go build -v -buildmode=c-shared -o proxy/planetscale-linux.so


### PR DESCRIPTION
This creates a shared object file for both amd64 and arm64 that can be used on MacOS transparently independent of the underlying architecture.