### PR TITLE
Better cross compile for Go bits

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,16 +4,16 @@ agents:
 steps:
 - name: "Go build"
   commands:
-    - "go build -v -x -buildmode=c-shared -o planetscale-linux.so.$BUILDKITE_COMMIT"
-    - "buildkite-agent artifact upload planetscale-linux.so.$BUILDKITE_COMMIT"
+    - "go build -v -x -trimpath -ldflags='-s -w' -buildmode=c-shared -o planetscale-linux-x86_64.so.$BUILDKITE_COMMIT"
+    - "buildkite-agent artifact upload planetscale-linux-x86_64.so.$BUILDKITE_COMMIT"
   plugins:
     - docker#v3.8.0:
-        image: "golang:1.16.4"
+        image: "golang:1.17.4"
 - wait
 - name: "Ruby build and test %n"
   commands:
     - "mkdir proxy"
-    - "buildkite-agent artifact download planetscale-linux.so.$BUILDKITE_COMMIT proxy/ && mv proxy/planetscale-linux.so.$BUILDKITE_COMMIT proxy/planetscale-linux.so"
+    - "buildkite-agent artifact download planetscale-linux-x86_64.so.$BUILDKITE_COMMIT proxy/ && mv proxy/planetscale-linux-x86_64.so.$BUILDKITE_COMMIT proxy/planetscale-linux-x86_64.so"
     - "bundle install -j 8"
     - "bundle exec rake test"
   plugins:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
 
     - name: Build and Test
       run: |
-        go build -v -buildmode=c-shared -o proxy/planetscale-linux.so
+        go build -v -buildmode=c-shared -trimpath -ldflags='-s -w' -o proxy/planetscale-linux-x86_64.so
         bundle exec rake test

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -34,7 +34,7 @@ jobs:
       uses: docker-practice/actions-setup-docker@master
 
     - name: Build shared library on Linux
-      run: docker run -v $(pwd):/planetscale-ruby golang sh -c 'cd /planetscale-ruby && go build -v -buildmode=c-shared -o proxy/planetscale-linux.so'
+      run: docker run -v $(pwd):/planetscale-ruby golang sh -c 'cd /planetscale-ruby && bin/build-linux'
 
     - name: Publish to GPR
       run: |

--- a/bin/build-darwin
+++ b/bin/build-darwin
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GOOS=darwin GOARCH=amd64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-amd64.so
-GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -o proxy/planetscale-darwin-arm64.so
+CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags '-w -s' -buildmode=c-shared -o proxy/planetscale-darwin-x86_64.so
+CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags '-w -s' -buildmode=c-shared -o proxy/planetscale-darwin-arm64.so
 
-lipo -create -output proxy/planetscale-darwin.so proxy/planetscale-darwin-amd64.so proxy/planetscale-darwin-arm64.so
+rm proxy/*.h
 
-rm -rf proxy/planetscale-darwin-amd64.so proxy/planetscale-darwin-arm64.so
-
-file proxy/planetscale-darwin.so
+file proxy/planetscale-darwin-x86_64.so
+file proxy/planetscale-darwin-arm64.so

--- a/bin/build-linux
+++ b/bin/build-linux
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt-get update && apt-get install --no-install-recommends --yes gcc-aarch64-linux-gnu gcc-mingw-w64 libc6-dev-arm64-cross file
+
+CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-w -s' -buildmode=c-shared -o proxy/planetscale-linux-x86_64.so
+CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -trimpath -ldflags='-w -s' -buildmode=c-shared -o proxy/planetscale-linux-arm64.so
+CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc go build -trimpath -ldflags='-w -s' -buildmode=c-shared -o proxy/planetscale-windows-x86_64.so
+
+rm proxy/*.h
+
+file proxy/planetscale-linux-x86_64.so
+file proxy/planetscale-linux-arm64.so
+file proxy/planetscale-windows-x86_64.so

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,7 @@ case $OS in
     bin/build-darwin
     ;;
   'Linux')
-    go build -v -buildmode=c-shared -o proxy/planetscale-linux.so
+    go build -v -buildmode=c-shared -trimpath -ldflags='-s -w' -o proxy/planetscale-linux-x86_64.so
     ;;
   *) ;;
 esac

--- a/lib/planetscale.rb
+++ b/lib/planetscale.rb
@@ -27,7 +27,8 @@ module PlanetScale
       layout :r0, :pointer, :r1, :pointer
     end
 
-    ffi_lib File.expand_path("../../proxy/planetscale-#{Gem::Platform.local.os}.so", __FILE__)
+    OS = Gem.win_platform? ? "windows" : Gem::Platform.local.os
+    ffi_lib File.expand_path("../../proxy/planetscale-#{OS}-#{Gem::Platform.local.cpu}.so", __FILE__)
     attach_function :startfromenv, %i[string string string string], ProxyReturn.by_value
     attach_function :startfromtoken, %i[string string string string string string], ProxyReturn.by_value
     attach_function :startfromstatic, %i[string string string string string string string string string], ProxyReturn.by_value


### PR DESCRIPTION
Turns out that the single universal binary doesn't actually work when testing on arm64 (M1), so we need to build separate images. FFI doesn't like loading from the shared one.

While we're at it, also add support for Linux arm64 & a Windows build.